### PR TITLE
Update 1123.md

### DIFF
--- a/software/2015/1123.md
+++ b/software/2015/1123.md
@@ -146,7 +146,7 @@ http://www.zhangxinxu.com/wordpress/2015/11/css3-will-change-improve-paint/
 
 **JavaScript 异步方案 async/await**
 https://blog.leancloud.cn/3910/
-JavaScript 一直想在语言层面彻底解决异步调用这个问题，在 ES6 中就已经支持原生的 Promise，还引入了 Generator 函数，终于在 ES7 中决定支持 async 和 await。
+JavaScript 在 ES6 中就已经支持原生的 Promise，还引入了 Generator 函数，终于在 ES7 中决定支持 async 和 await。
 
 **Goo Engine 开源**
 http://goocreate.com/blog/1199/oh-my-code-goo-engine-goes-open-source/


### PR DESCRIPTION
> JavaScript 一直想在语言层面彻底解决异步调用这个问题，在 ES6 中就已经支持原生的 Promise，还引入了 Generator 函数，终于在 ES7 中决定支持 async 和 await。

这句话的问题包括：
- generator 的引入不是为了「解决异步问题」
- 严格说，Promise 也不局限于「解决异步问题」
- 「异步调用」本身不是一个问题